### PR TITLE
WIP: Adding ability to specify a port for local unbound

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,6 +2,9 @@
 # Primary DNS server, usually your local Unbound instance or another upstream DNS
 primary_dns = 127.0.0.1
 
+# Primary DNS server port, usually using the local unbound with pi-hole this is 5335
+primary_dns_port = 5335
+
 # Fallback DNS server to use if primary is unhealthy (e.g., Cloudflare, Google, OpenDNS)
 fallback_dns = 1.1.1.1
 

--- a/dns_fallback_proxy.py
+++ b/dns_fallback_proxy.py
@@ -22,6 +22,7 @@ except Exception as e:
 
 # Proxy settings
 PRIMARY_DNS = config.get('Proxy', 'primary_dns', fallback="127.0.0.1")
+PRIMARY_DNS_PORT = config.get('Proxy', 'primary_dns_port', fallback=53)
 FALLBACK_DNS = config.get('Proxy', 'fallback_dns', fallback="1.1.1.1")
 DNS_PORT = config.getint('Proxy', 'dns_port', fallback=5353)
 HEALTH_CHECK_INTERVAL = config.getint('Proxy', 'health_check_interval', fallback=10)
@@ -69,7 +70,7 @@ class DNSServer:
     It forwards DNS queries to a primary DNS server (e.g., Unbound) and
     switches to a fallback DNS server (e.g., 1.1.1.1) if the primary becomes unhealthy.
     """
-    def __init__(self, primary_dns: str, fallback_dns: str, dns_port: int,
+    def __init__(self, primary_dns: str, primary_dns_port: int, fallback_dns: str, dns_port: int,
                  health_check_interval: int, pid_file: str, buffer_size: int,
                  failure_threshold: int):
         """
@@ -77,6 +78,7 @@ class DNSServer:
 
         Args:
             primary_dns: The IP address of the primary DNS server.
+            primary_dns_port: The Port of the primary DNS server
             fallback_dns: The IP address of the fallback DNS server.
             dns_port: The UDP port the proxy should listen on.
             health_check_interval: The interval (in seconds) between health checks.
@@ -85,6 +87,7 @@ class DNSServer:
             failure_threshold: Number of consecutive health check failures before switching.
         """
         self.primary_dns = primary_dns
+        self.primary_dns_port = int(primary_dns_port)
         self.fallback_dns = fallback_dns
         self.port = dns_port
         self.pid_file = pid_file
@@ -93,13 +96,14 @@ class DNSServer:
         self.failure_threshold = failure_threshold
 
         self.current_dns = self.primary_dns
+        self.current_dns_port = self.primary_dns_port
         self.last_health_check_time = 0
         self.consecutive_health_failures = 0
         self.running = False
         self.sock: socket.socket | None = None # Explicitly type sock for clarity
 
         logger.info(f"DNS Fallback Proxy initialized.")
-        logger.info(f"Primary DNS: {self.primary_dns}, Fallback DNS: {self.fallback_dns}")
+        logger.info(f"Primary DNS: {self.primary_dns}:{self.primary_dns_port}, Fallback DNS: {self.fallback_dns}")
         logger.info(f"Listening on port: {self.port}")
         logger.info(f"Health check interval: {self.health_check_interval} seconds, Failure threshold: {self.failure_threshold}.")
 
@@ -127,12 +131,13 @@ class DNSServer:
             self.sock.close()
             logger.info("Closed main server socket.")
 
-    def _send_dns_query(self, dns_server: str, query_data: bytes, timeout: float = 1.0, retries: int = 3) -> bytes | None:
+    def _send_dns_query(self, dns_server: str, query_data: bytes, dns_server_port: int = 53, timeout: float = 1.0, retries: int = 3) -> bytes | None:
         """
         Sends a DNS query to the specified DNS server with retries.
 
         Args:
             dns_server: The IP address of the DNS server to query.
+            dns_server_port: The Port of the DNS server to query - defaults to 53
             query_data: The raw DNS query packet.
             timeout: The timeout for each socket operation in seconds.
             retries: Number of retry attempts.
@@ -144,29 +149,29 @@ class DNSServer:
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
                     sock.settimeout(timeout)
-                    sock.sendto(query_data, (dns_server, 53))
+                    sock.sendto(query_data, (dns_server, dns_server_port))
                     response_data, _ = sock.recvfrom(self.buffer_size)
-                    logger.debug(f"Successfully received response from {dns_server} on attempt {attempt + 1}/{retries}.")
+                    logger.debug(f"Successfully received response from {dns_server}:{dns_server_port} on attempt {attempt + 1}/{retries}.")
                     return response_data
             except socket.timeout:
-                logger.warning(f"DNS query to {dns_server} timed out on attempt {attempt + 1}/{retries}.")
+                logger.warning(f"DNS query to {dns_server}:{dns_server_port} timed out on attempt {attempt + 1}/{retries}.")
             except socket.gaierror as e:
-                logger.error(f"Address resolution error for {dns_server} on attempt {attempt + 1}/{retries}: {e}. (Likely permanent error for this server)")
+                logger.error(f"Address resolution error for {dns_server}:{dns_server_port} on attempt {attempt + 1}/{retries}: {e}. (Likely permanent error for this server)")
                 return None # No point in retrying for address errors
             except socket.error as e:
-                logger.warning(f"Socket error during DNS query to {dns_server} on attempt {attempt + 1}/{retries}: {e}.")
+                logger.warning(f"Socket error during DNS query to {dns_server}:{dns_server_port} on attempt {attempt + 1}/{retries}: {e}.")
             except DNSError as e:
-                logger.warning(f"Malformed DNS response from {dns_server} on attempt {attempt + 1}/{retries}: {e}.")
+                logger.warning(f"Malformed DNS response from {dns_server}:{dns_server_port} on attempt {attempt + 1}/{retries}: {e}.")
             except Exception as e:
-                logger.exception(f"An unexpected error occurred during DNS query to {dns_server} on attempt {attempt + 1}/{retries}.")
+                logger.exception(f"An unexpected error occurred during DNS query to {dns_server}:{dns_server_port} on attempt {attempt + 1}/{retries}.")
 
             if attempt < retries - 1:
                 time.sleep(0.1 * (2 ** attempt)) # Exponential backoff: 0.1s, 0.2s, 0.4s...
 
-        logger.error(f"DNS query to {dns_server} failed after {retries} attempts.")
+        logger.error(f"DNS query to {dns_server}:{dns_server_port} failed after {retries} attempts.")
         return None
 
-    def _check_dns_health(self, dns_server: str) -> bool:
+    def _check_dns_health(self, dns_server: str, dns_server_port: int = 53) -> bool:
         """
         Checks the health of a given DNS server by querying multiple well-known hosts.
         Returns True if at least one query succeeds and returns a valid DNS response,
@@ -179,20 +184,20 @@ class DNSServer:
             try:
                 q = DNSRecord.question(domain, test_query_type)
                 query_data = q.pack()
-                response = self._send_dns_query(dns_server, query_data, timeout=0.5, retries=1) # Quick check, no retries for health check specifically
+                response = self._send_dns_query(dns_server, dns_server_port, query_data, timeout=0.5, retries=1) # Quick check, no retries for health check specifically
                 if response:
                     # Attempt to parse response to ensure it's a valid DNS packet
                     DNSRecord.parse(response)
-                    logger.debug(f"Health check for '{domain}' on {dns_server} succeeded.")
+                    logger.debug(f"Health check for '{domain}' on {dns_server}:{dns_server_port} succeeded.")
                     return True # Found a healthy response
                 else:
-                    logger.debug(f"Health check for '{domain}' on {dns_server} failed (no response).")
+                    logger.debug(f"Health check for '{domain}' on {dns_server}:{dns_server_port} failed (no response).")
             except DNSError:
-                logger.warning(f"Health check for '{domain}' on {dns_server} returned malformed DNS response.")
+                logger.warning(f"Health check for '{domain}' on {dns_server}:{dns_server_port} returned malformed DNS response.")
             except Exception as e:
-                logger.error(f"Unexpected error during health check for '{domain}' on {dns_server}: {e}")
+                logger.error(f"Unexpected error during health check for '{domain}' on {dns_server}:{dns_server_port}: {e}")
 
-        logger.warning(f"All health checks to {dns_server} failed.")
+        logger.warning(f"All health checks to {dns_server}:{dns_server_port} failed.")
         return False
 
     def _health_check_loop(self):
@@ -206,18 +211,20 @@ class DNSServer:
                 self.last_health_check_time = current_time
 
                 # Check primary DNS health
-                is_primary_healthy = self._check_dns_health(self.primary_dns)
+                is_primary_healthy = self._check_dns_health(self.primary_dns, self.primary_dns_port)
 
                 if not is_primary_healthy:
                     self.consecutive_health_failures += 1
-                    logger.warning(f"Primary DNS ({self.primary_dns}) health check failed. Consecutive failures: {self.consecutive_health_failures}/{self.failure_threshold}.")
+                    logger.warning(f"Primary DNS ({self.primary_dns}:{self.primary_dns_port}) health check failed. Consecutive failures: {self.consecutive_health_failures}/{self.failure_threshold}.")
                     if self.consecutive_health_failures >= self.failure_threshold and self.current_dns != self.fallback_dns:
-                        logger.warning(f"Primary DNS ({self.primary_dns}) is unhealthy after {self.failure_threshold} consecutive failures. Switching to fallback ({self.fallback_dns}).")
+                        logger.warning(f"Primary DNS ({self.primary_dns}:{self.primary_dns_port}) is unhealthy after {self.failure_threshold} consecutive failures. Switching to fallback ({self.fallback_dns}).")
                         self.current_dns = self.fallback_dns
+                        self.current_dns_port = 53
                 else:
                     if self.current_dns == self.fallback_dns:
-                        logger.info(f"Primary DNS ({self.primary_dns}) is now healthy. Switching back.")
+                        logger.info(f"Primary DNS ({self.primary_dns}:{self.primary_dns_port}) is now healthy. Switching back.")
                         self.current_dns = self.primary_dns
+                        self.current_dns_port = self.primary_dns_port
                     self.consecutive_health_failures = 0 # Reset counter on success
 
             time.sleep(1) # Check every second if interval is passed
@@ -237,14 +244,14 @@ class DNSServer:
             logger.debug(f"Received DNS query from {client_address}: {dns_query.q.qname} (Type: {QTYPE[dns_query.q.qtype]})")
 
             # Forward query to the current active DNS server
-            response_data = self._send_dns_query(self.current_dns, data)
+            response_data = self._send_dns_query(self.current_dns, data, self.current_dns_port)
 
             if response_data:
                 # Send the response back to the client
                 self.sock.sendto(response_data, client_address)
-                logger.debug(f"Forwarded response from {self.current_dns} to {client_address}.")
+                logger.debug(f"Forwarded response from {self.current_dns}:{self.current_dns_port} to {client_address}.")
             else:
-                logger.error(f"No response from {self.current_dns} for query {dns_query.q.qname}. Not sending response to {client_address}.")
+                logger.error(f"No response from {self.current_dns}:{self.current_dns_port} for query {dns_query.q.qname}. Not sending response to {client_address}.")
 
         except DNSError as e:
             logger.error(f"Malformed DNS query from {client_address}: {e}")
@@ -309,6 +316,7 @@ class DNSServer:
 if __name__ == "__main__":
     server = DNSServer(
         primary_dns=PRIMARY_DNS,
+        primary_dns_port=PRIMARY_DNS_PORT,
         fallback_dns=FALLBACK_DNS,
         dns_port=DNS_PORT,
         health_check_interval=HEALTH_CHECK_INTERVAL,


### PR DESCRIPTION
This pull request introduces support for specifying a custom port for the primary DNS server in the DNS fallback proxy system. The changes ensure that the primary DNS port can be configured dynamically, improving flexibility and compatibility with setups like Pi-hole using non-standard ports.

### Configuration Updates:
* Added `primary_dns_port` configuration option in `config.ini` to specify the port used by the primary DNS server. Default value is set to `5335`.

### Code Enhancements:
* Updated `dns_fallback_proxy.py`:
  - Added support for `primary_dns_port` in the `DNSServer` class initialization and internal logic, ensuring all DNS queries and health checks include the port. [[1]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421R25) [[2]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421L72-R81) [[3]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421R90) [[4]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421R99-R106)
  - Modified `_send_dns_query` and `_check_dns_health` methods to accept and use the DNS server port, defaulting to `53` for fallback scenarios. [[1]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421L130-R140) [[2]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421L147-R174) [[3]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421L182-R200)
  - Enhanced logging to include the port in DNS server-related messages for better traceability. [[1]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421R99-R106) [[2]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421L147-R174) [[3]](diffhunk://#diff-a7076654a837c34892d9ab0f58bc910e8cd583a21759572f0d35df1528e50421L209-R227)
  - Updated `_health_check_loop` to dynamically switch between primary and fallback DNS ports during health checks and transitions.
  - Adjusted `_handle_dns_request` to forward queries using the active DNS server's port.
  - Passed `primary_dns_port` to the `DNSServer` instance in the `start` method.